### PR TITLE
Update ci.yml for Github Action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   codeowners:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.7.1
         with:


### PR DESCRIPTION
## Description

Support for Ubuntu 18 in Github Actions is deprecated and will be removed altogether in April 2023 - so this PR updates the CI workflow to us Ubuntu 22 - an LTS release with several more years of support at minimum.

This change also updates the use of `actions/checkout` to `@v3` - which addresses a deprecation warning around an outdated Node version usage under-the-hood.

## Related links

- https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
- https://github.com/actions/checkout/issues/959
